### PR TITLE
[Infra] update OcMesher version number for Infinigen-Sim compatibility

### DIFF
--- a/ocmesher/__init__.py
+++ b/ocmesher/__init__.py
@@ -1,3 +1,3 @@
 from .core import OcMesher
 
-__version__ = "1.0"
+__version__ = "2.0"


### PR DESCRIPTION
Infinigen's current release requires OcMesher version 2.0, last update to parent repository owned by Princeton VL lab is under version 1.0. Since the codebase appears to be stable, I'm manually updating the version of this fork to 2.0.